### PR TITLE
Correct way to get config parameters

### DIFF
--- a/src/Triggerdesign/Hermes/BaseMigration.php
+++ b/src/Triggerdesign/Hermes/BaseMigration.php
@@ -9,20 +9,20 @@ use Illuminate\Database\Migrations\Migration;
 class BaseMigration extends Migration {
 
     protected function tableName($name){
-        $prefix = Config::get('hermes::tablePrefix', '');
+        $prefix = Config::get('hermes.tablePrefix', '');
 
         return $prefix . $name;
     }
 
     protected function usersTable(){
-        $usersTableConfig = Config::get('hermes::usersTable', 'users');
+        $usersTableConfig = Config::get('hermes.usersTable', 'users');
 
 
         return $usersTableConfig;
     }
     
     protected function useForeignKeys(){
-    	$useForeignKeys = Config::get('hermes::useForeignKeys', false); 	
+    	$useForeignKeys = Config::get('hermes.useForeignKeys', false);
     	
     	return $useForeignKeys;
     }

--- a/src/models/EloquentBase.php
+++ b/src/models/EloquentBase.php
@@ -15,15 +15,15 @@ class EloquentBase extends \Eloquent {
 
     public static function userClass(){
 
-        return \Config::get('hermes::userClass', '\App\User');
+        return \Config::get('hermes.userClass', '\App\User');
     }
 
     public static function tableName($name){
     	if($name == 'users'){
-    		return \Config::get('hermes::usersTable', 'users');
+    		return \Config::get('hermes.usersTable', 'users');
     	}    	
     	
-        $prefix = \Config::get('hermes::tablePrefix', '');
+        $prefix = \Config::get('hermes.tablePrefix', '');
 
       
         


### PR DESCRIPTION
It didn't work with config.

According to 
https://laravel.com/docs/5.2/configuration
https://laracasts.com/discuss/channels/general-discussion/ho-to-access-config-variables-in-laravel-5?page=1

this is a correct way of using variables from config files in Laravel 5.

I've tested with my own installation, if I use in config:
'userClass' => '\App\Models\User',

it works as expected
